### PR TITLE
Add output to configuration options

### DIFF
--- a/SierraSam.Core.Tests.Unit/ConfigurationBuilders/ArgsConfigurationBuilderTests.cs
+++ b/SierraSam.Core.Tests.Unit/ConfigurationBuilders/ArgsConfigurationBuilderTests.cs
@@ -52,6 +52,11 @@ internal sealed class ArgsConfigurationBuilderTests
                 new[] { "verb", "--ignoredMigrations=*:*" },
                 new Configuration(ignoredMigrations: new[] {"*:*"}))
             .SetName("ignored migrations is set correctly");
+
+        yield return new TestCaseData(
+                new[] { "verb", "--output=none" },
+                new Configuration(output: "none"))
+            .SetName("output is set correctly");
     }
 
     [TestCaseSource(nameof(Get_config_overrides))]
@@ -65,8 +70,10 @@ internal sealed class ArgsConfigurationBuilderTests
 
         var loggerFactory = Substitute.For<ILoggerFactory>();
 
-        var argsConfigurationBuilder = new ArgsConfigurationReader
-            (loggerFactory, args, configurationBuilder);
+        var argsConfigurationBuilder = new ArgsConfigurationReader(
+            loggerFactory,
+            args,
+            configurationBuilder);
 
         argsConfigurationBuilder.Read().Should().BeEquivalentTo(expected);
     }

--- a/SierraSam.Core/Configuration.cs
+++ b/SierraSam.Core/Configuration.cs
@@ -26,6 +26,7 @@ public class Configuration : IConfiguration
         UndoMigrationPrefix = "U";
         IgnoredMigrations = new[] { "*:pending" };
         InitialiseVersion = string.Empty;
+        Output = "json";
     }
 
     public Configuration(
@@ -45,7 +46,8 @@ public class Configuration : IConfiguration
         string? repeatableMigrationPrefix = null,
         string? undoMigrationPrefix = null,
         IEnumerable<string>? ignoredMigrations = null,
-        string? initialiseVersion = null)
+        string? initialiseVersion = null,
+        string? output = null)
     {
         Url = url ?? string.Empty;
         User = user ?? string.Empty;
@@ -64,6 +66,7 @@ public class Configuration : IConfiguration
         UndoMigrationPrefix = undoMigrationPrefix ?? "U";
         IgnoredMigrations = ignoredMigrations ?? new[] { "*:pending" };
         InitialiseVersion = initialiseVersion ?? string.Empty;
+        Output = output ?? "json";
     }
 
     [JsonPropertyName("url"), JsonInclude]
@@ -122,4 +125,7 @@ public class Configuration : IConfiguration
 
     [JsonPropertyName("initialiseVersion"), JsonInclude]
     public string InitialiseVersion { get; set; }
+
+    [JsonPropertyName("output"), JsonInclude]
+    public string Output { get; set; }
 }

--- a/SierraSam.Core/ConfigurationReaders/ArgsConfigurationReader.cs
+++ b/SierraSam.Core/ConfigurationReaders/ArgsConfigurationReader.cs
@@ -106,6 +106,9 @@ internal sealed class ArgsConfigurationReader : IConfigurationReader
                 case "--initialiseVersion":
                     configuration.InitialiseVersion = kvp.Value;
                     break;
+                case "--output":
+                    configuration.Output = kvp.Value;
+                    break;
                 default:
                     throw new Exception($"Invalid argument '{kvp.Key}'");
             }

--- a/SierraSam.Core/IConfiguration.cs
+++ b/SierraSam.Core/IConfiguration.cs
@@ -19,4 +19,5 @@ public interface IConfiguration
     string UndoMigrationPrefix { get; set; }
     IEnumerable<string> IgnoredMigrations { get; set; }
     string InitialiseVersion { get; set; }
+    public string Output { get; set; }
 }


### PR DESCRIPTION
## What
Add output to configuration options

## Why
So a user can customise the output of the CLI