### PR TITLE
Export migrations to multiple output formats

### DIFF
--- a/SierraSam.Core.Tests.Unit/Factories/SerializerFactoryTests.cs
+++ b/SierraSam.Core.Tests.Unit/Factories/SerializerFactoryTests.cs
@@ -8,7 +8,9 @@ namespace SierraSam.Core.Tests.Unit.Factories;
 internal sealed class SerializerFactoryTests
 {
     [TestCase("json", typeof(JsonSerializer))]
+    [TestCase("jsonc", typeof(JsoncSerializer))]
     [TestCase("yaml", typeof(YamlSerializer))]
+    [TestCase("yamlc", typeof(YamlcSerializer))]
     [TestCase("none", typeof(EmptySerializer))]
     public void Factory_creates_correct_implementation_from_configuration(
         string output,

--- a/SierraSam.Core.Tests.Unit/Factories/SerializerFactoryTests.cs
+++ b/SierraSam.Core.Tests.Unit/Factories/SerializerFactoryTests.cs
@@ -1,0 +1,24 @@
+﻿using FluentAssertions;
+using NSubstitute;
+using SierraSam.Core.Factories;
+using SierraSam.Core.Serializers;
+
+namespace SierraSam.Core.Tests.Unit.Factories;
+
+internal sealed class SerializerFactoryTests
+{
+    [TestCase("json", typeof(JsonSerializer))]
+    [TestCase("yaml", typeof(YamlSerializer))]
+    [TestCase("none", typeof(EmptySerializer))]
+    public void Factory_creates_correct_implementation_from_configuration(
+        string output,
+        Type implementation)
+    {
+        var configuration = Substitute.For<IConfiguration>();
+        configuration.Output.Returns(output);
+
+        var result = SerializerFactory.Create(configuration);
+
+        result.Should().BeOfType(implementation);
+    }
+}

--- a/SierraSam.Core.Tests.Unit/Serializers/EmptySerializerTests.cs
+++ b/SierraSam.Core.Tests.Unit/Serializers/EmptySerializerTests.cs
@@ -1,0 +1,28 @@
+﻿using FluentAssertions;
+using SierraSam.Core.Enums;
+using Spectre.Console;
+
+namespace SierraSam.Core.Tests.Unit.Serializers;
+
+[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+internal sealed class EmptySerializerTests
+{
+    private readonly Core.Serializers.EmptySerializer _serializer = new();
+
+    [Test]
+    public void Serialize_returns_expected_response()
+    {
+        var content = new TerseMigration(
+            MigrationType.Versioned,
+            "1",
+            "someDescription",
+            "someType",
+            "someChecksum",
+            DateTime.UtcNow,
+            MigrationState.Pending);
+
+        var result = _serializer.Serialize(content);
+
+        result.Should().BeEquivalentTo(Text.Empty);
+    }
+}

--- a/SierraSam.Core.Tests.Unit/Serializers/JsonSerializerTests.cs
+++ b/SierraSam.Core.Tests.Unit/Serializers/JsonSerializerTests.cs
@@ -1,0 +1,46 @@
+﻿using FluentAssertions;
+using SierraSam.Core.Enums;
+using Spectre.Console.Testing;
+
+namespace SierraSam.Core.Tests.Unit.Serializers;
+
+[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+internal sealed class JsonSerializerTests
+{
+    private readonly Core.Serializers.JsonSerializer _serializer = new();
+    private readonly TestConsole _console = new ();
+
+    [Test]
+    public void Serialize_returns_expected_response()
+    {
+        var installedOn = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var content = new TerseMigration(
+            MigrationType.Versioned,
+            "1",
+            "someDescription",
+            "someType",
+            "someChecksum",
+            installedOn,
+            MigrationState.Pending);
+
+        var result = _serializer.Serialize(content);
+
+        _console.Write(result);
+
+        const string expected =
+            """
+            {
+              "MigrationType": "Versioned",
+              "Version": "1",
+              "Description": "someDescription",
+              "Type": "someType",
+              "Checksum": "someChecksum",
+              "InstalledOn": "2023-01-01T00:00:00Z",
+              "State": "Pending"
+            }
+            """;
+
+        _console.Output.Should().Be(expected.NormalizeLineEndings());
+    }
+}

--- a/SierraSam.Core.Tests.Unit/Serializers/TableSerializerTests.cs
+++ b/SierraSam.Core.Tests.Unit/Serializers/TableSerializerTests.cs
@@ -1,0 +1,63 @@
+﻿using FluentAssertions;
+using SierraSam.Core.Serializers;
+using Spectre.Console.Testing;
+
+namespace SierraSam.Core.Tests.Unit.Serializers;
+
+[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+internal sealed class TableSerializerTests
+{
+    private readonly TableSerializer _serializer = new();
+    private readonly TestConsole _console = new ();
+
+    private record ExampleForTest(string Forename, string Surname);
+
+    [Test]
+    public void Serialize_returns_expected_response()
+    {
+        var content = new ExampleForTest[]
+        {
+            new ("Joe", "Blogs"),
+            new ("Karen", "Smith")
+        };
+
+        var result = _serializer.Serialize(content);
+
+        _console.Write(result);
+
+        const string expected =
+            """
+                                  
+            | Forename | Surname |
+            | :------- | :------ |
+            | Joe      | Blogs   |
+            | Karen    | Smith   |
+                                  
+            
+            """;
+
+        _console.Output.Should().Be(expected.NormalizeLineEndings());
+    }
+
+    [Test]
+    public void Serialize_returns_expected_response_for_non_array()
+    {
+        var content = new ExampleForTest("Joe", "Blogs");
+
+        var result = _serializer.Serialize(content);
+
+        _console.Write(result);
+
+        const string expected =
+            """
+                                  
+            | Forename | Surname |
+            | :------- | :------ |
+            | Joe      | Blogs   |
+                                  
+            
+            """;
+
+        _console.Output.Should().Be(expected.NormalizeLineEndings());
+    }
+}

--- a/SierraSam.Core.Tests.Unit/Serializers/YamlSerializerTests.cs
+++ b/SierraSam.Core.Tests.Unit/Serializers/YamlSerializerTests.cs
@@ -1,0 +1,76 @@
+﻿using FluentAssertions;
+using SierraSam.Core.Enums;
+using SierraSam.Core.Serializers;
+using Spectre.Console.Testing;
+
+namespace SierraSam.Core.Tests.Unit.Serializers;
+
+[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+internal sealed class YamlSerializerTests
+{
+    private readonly YamlSerializer _serializer = new();
+    private readonly TestConsole _console = new ();
+
+    [Test]
+    public void Serialize_returns_expected_response()
+    {
+        var installedOn = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var content = new TerseMigration(
+            MigrationType.Versioned,
+            "1",
+            "someDescription",
+            "someType",
+            "someChecksum",
+            installedOn,
+            MigrationState.Pending);
+
+        var result = _serializer.Serialize(content);
+
+        _console.Write(result);
+
+        const string expected =
+            """
+            migrationType: Versioned
+            version: 1
+            description: someDescription
+            type: someType
+            checksum: someChecksum
+            installedOn: 2023-01-01T00:00:00.0000000Z
+            state: Pending
+            
+            """;
+
+        _console.Output.Should().Be(expected.NormalizeLineEndings());
+    }
+
+    [Test]
+    public void Serialize_ignores_null_values()
+    {
+        var content = new TerseMigration(
+            MigrationType.Versioned,
+            "1",
+            "someDescription",
+            "someType",
+            "someChecksum",
+            null,
+            MigrationState.Pending);
+
+        var result = _serializer.Serialize(content);
+
+        _console.Write(result);
+
+        const string expected =
+            """
+            migrationType: Versioned
+            version: 1
+            description: someDescription
+            type: someType
+            checksum: someChecksum
+            state: Pending
+            
+            """;
+
+        _console.Output.Should().Be(expected.NormalizeLineEndings());
+    }
+}

--- a/SierraSam.Core.Tests.Unit/SierraSam.Core.Tests.Unit.csproj
+++ b/SierraSam.Core.Tests.Unit/SierraSam.Core.Tests.Unit.csproj
@@ -17,6 +17,7 @@
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
         <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
         <PackageReference Include="coverlet.collector" Version="6.0.0" />
+        <PackageReference Include="Spectre.Console.Testing" Version="0.47.0" />
         <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="19.2.69" />
     </ItemGroup>
 

--- a/SierraSam.Core/Factories/SerializerFactory.cs
+++ b/SierraSam.Core/Factories/SerializerFactory.cs
@@ -1,0 +1,20 @@
+﻿using SierraSam.Core.Serializers;
+
+namespace SierraSam.Core.Factories;
+
+public static class SerializerFactory
+{
+    public static ISerializer Create(IConfiguration configuration)
+    {
+        return configuration.Output switch
+        {
+            "json" => new JsonSerializer(),
+            "jsonc" => new JsoncSerializer(),
+            "yaml" => new YamlSerializer(),
+            "yamlc" => new YamlcSerializer(),
+            "table" => new TableSerializer(),
+            "none" => new EmptySerializer(),
+            _ => throw new ArgumentOutOfRangeException()
+        };
+    }
+}

--- a/SierraSam.Core/Serializers/EmptySerializer.cs
+++ b/SierraSam.Core/Serializers/EmptySerializer.cs
@@ -1,0 +1,9 @@
+﻿using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace SierraSam.Core.Serializers;
+
+internal sealed class EmptySerializer : ISerializer
+{
+    public IRenderable Serialize<T>(T content) => new Text(string.Empty);
+}

--- a/SierraSam.Core/Serializers/ISerializer.cs
+++ b/SierraSam.Core/Serializers/ISerializer.cs
@@ -1,0 +1,8 @@
+﻿using Spectre.Console.Rendering;
+
+namespace SierraSam.Core.Serializers;
+
+public interface ISerializer
+{
+    IRenderable Serialize<T>(T content);
+}

--- a/SierraSam.Core/Serializers/JsonSerializer.cs
+++ b/SierraSam.Core/Serializers/JsonSerializer.cs
@@ -1,0 +1,26 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace SierraSam.Core.Serializers;
+
+internal sealed class JsonSerializer : ISerializer
+{
+    public IRenderable Serialize<T>(T content)
+    {
+        var json = System.Text.Json.JsonSerializer.Serialize(
+            content,
+            new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                Converters =
+                {
+                    new JsonStringEnumConverter()
+                }
+            }
+        );
+
+        return new Text(json);
+    }
+}

--- a/SierraSam.Core/Serializers/JsoncSerializer.cs
+++ b/SierraSam.Core/Serializers/JsoncSerializer.cs
@@ -1,0 +1,34 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using Spectre.Console.Json;
+using Spectre.Console.Rendering;
+using Color = Spectre.Console.Color;
+
+namespace SierraSam.Core.Serializers;
+
+internal sealed class JsoncSerializer : ISerializer
+{
+    public IRenderable Serialize<T>(T content)
+    {
+        var json = System.Text.Json.JsonSerializer.Serialize(
+            content,
+            new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                Converters =
+                {
+                    new JsonStringEnumConverter(),
+                }
+            }
+        );
+
+        return new JsonText(json)
+            .MemberColor(new Color(114, 159, 207))
+            .StringColor(new Color(196, 160, 0))
+            .BooleanColor(new Color(52, 101, 164))
+            .NullColor(Color.Red3)
+            .ColonColor(Color.White)
+            .BracketColor(Color.White)
+            .BracesColor(Color.White);
+    }
+}

--- a/SierraSam.Core/Serializers/TableSerializer.cs
+++ b/SierraSam.Core/Serializers/TableSerializer.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace SierraSam.Core.Serializers;
+
+internal sealed class TableSerializer : ISerializer
+{
+    public IRenderable Serialize<T>(T content)
+    {
+        ArgumentNullException.ThrowIfNull(content, nameof(content));
+
+        var type = typeof(T) switch
+        {
+            { IsGenericType: true } => typeof(T).GetGenericArguments().First(),
+            { IsArray: true } or { IsPointer: true } and { IsByRef: true } => typeof(T).GetElementType()!,
+            _ => typeof(T)
+        };
+
+        var properties = type.GetProperties();
+
+        var table = new Table
+        {
+            Border = TableBorder.Markdown
+        };
+
+        foreach (var prop in properties)
+        {
+            table.AddColumn(prop.Name, column => column.Alignment = Justify.Left);
+        }
+
+        foreach (var obj in content as IEnumerable ?? new [] { content })
+        {
+            var values = new List<string>();
+            foreach (var prop in properties)
+            {
+                var value = prop.GetValue(obj);
+
+                values.Add(value?.ToString() ?? string.Empty);
+            }
+
+            table.AddRow(values.ToArray());
+        }
+
+        return table;
+    }
+}

--- a/SierraSam.Core/Serializers/YamlSerializer.cs
+++ b/SierraSam.Core/Serializers/YamlSerializer.cs
@@ -1,0 +1,19 @@
+﻿using Spectre.Console;
+using Spectre.Console.Rendering;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace SierraSam.Core.Serializers;
+
+internal sealed class YamlSerializer : ISerializer
+{
+    public IRenderable Serialize<T>(T content)
+    {
+        var builder = new SerializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
+            .Build();
+
+        return new Text(builder.Serialize(content));
+    }
+}

--- a/SierraSam.Core/Serializers/YamlcSerializer.cs
+++ b/SierraSam.Core/Serializers/YamlcSerializer.cs
@@ -1,0 +1,29 @@
+﻿using System.Text.RegularExpressions;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace SierraSam.Core.Serializers;
+
+internal sealed partial class YamlcSerializer : ISerializer
+{
+    public IRenderable Serialize<T>(T content)
+    {
+        var builder = new SerializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
+            .Build();
+
+        var yaml = YamlKeyRegex()
+            .Replace(
+                builder.Serialize(content),
+                match => $"[rgb(114,159,207)]{match.Value}[/]"
+            );
+
+        return new Markup(yaml);
+    }
+
+    [GeneratedRegex("[A-z]+(?=:\\s)")]
+    private static partial Regex YamlKeyRegex();
+}

--- a/SierraSam.Core/SierraSam.Core.csproj
+++ b/SierraSam.Core/SierraSam.Core.csproj
@@ -10,6 +10,7 @@
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
       <PackageReference Include="System.Data.Odbc" Version="7.0.0" />
       <PackageReference Include="System.IO.Abstractions" Version="19.2.69" />
+      <PackageReference Include="YamlDotNet" Version="13.5.2" />
     </ItemGroup>
     
     <ItemGroup>

--- a/SierraSam.Core/SierraSam.Core.csproj
+++ b/SierraSam.Core/SierraSam.Core.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="ConsoleTables" Version="2.5.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
       <PackageReference Include="System.Data.Odbc" Version="7.0.0" />
       <PackageReference Include="System.IO.Abstractions" Version="19.2.69" />

--- a/SierraSam.Core/SierraSam.Core.csproj
+++ b/SierraSam.Core/SierraSam.Core.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="ConsoleTables" Version="2.5.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+      <PackageReference Include="Spectre.Console.Json" Version="0.47.0" />
       <PackageReference Include="System.Data.Odbc" Version="7.0.0" />
       <PackageReference Include="System.IO.Abstractions" Version="19.2.69" />
       <PackageReference Include="YamlDotNet" Version="13.5.2" />

--- a/SierraSam.Tests.Unit/Capabilities/InformationTests.cs
+++ b/SierraSam.Tests.Unit/Capabilities/InformationTests.cs
@@ -3,6 +3,7 @@ using NSubstitute;
 using NUnit.Framework;
 using SierraSam.Core;
 using SierraSam.Capabilities;
+using SierraSam.Core.Serializers;
 
 namespace SierraSam.Tests.Unit.Capabilities;
 
@@ -15,7 +16,9 @@ internal sealed class InformationTests
 
         var migrationMerger = Substitute.For<IMigrationMerger>();
 
-        var sut = new Information(logger, migrationMerger);
+        var printer = Substitute.For<ISerializer>();
+
+        var sut = new Information(logger, migrationMerger, printer);
 
         Assert.DoesNotThrow(() => sut.Run(Array.Empty<string>()));
     }

--- a/SierraSam/Program.cs
+++ b/SierraSam/Program.cs
@@ -10,6 +10,7 @@ using SierraSam.Core;
 using SierraSam.Core.Factories;
 using SierraSam.Core.MigrationSeekers;
 using SierraSam.Core.MigrationValidators;
+using SierraSam.Core.Serializers;
 using SierraSam.Database;
 using Spectre.Console;
 using Version = SierraSam.Capabilities.Version;
@@ -102,6 +103,11 @@ public static class Program
                 services.AddSingleton<ICapability, Migrate>();
                 services.AddSingleton<ICapability, Validate>();
                 services.AddSingleton<ICapability, Version>();
+
+                services.AddSingleton<ISerializer>(
+                    s => SerializerFactory.Create(
+                        s.GetRequiredService<IConfiguration>())
+                );
             })
             .Build();
 

--- a/SierraSam/packages.lock.json
+++ b/SierraSam/packages.lock.json
@@ -337,12 +337,18 @@
           "TestableIO.System.IO.Abstractions": "19.2.69"
         }
       },
+      "YamlDotNet": {
+        "type": "Transitive",
+        "resolved": "13.5.2",
+        "contentHash": "HN+06WB25/yRiQYNansO5sHsNFYIHDaiquvfYOw5DQ4XWArlDtZxxsvll7eS7W3jzXZXeo/crfOnLpD0tXZkGw=="
+      },
       "sierrasam.core": {
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.1, )",
           "System.Data.Odbc": "[7.0.0, )",
-          "System.IO.Abstractions": "[19.2.69, )"
+          "System.IO.Abstractions": "[19.2.69, )",
+          "YamlDotNet": "[13.5.2, )"
         }
       },
       "sierrasam.database": {

--- a/SierraSam/packages.lock.json
+++ b/SierraSam/packages.lock.json
@@ -291,6 +291,14 @@
         "resolved": "7.0.0",
         "contentHash": "um1KU5kxcRp3CNuI8o/GrZtD4AIOXDk+RLsytjZ9QPok3ttLUelLKpilVPuaFT3TFjOhSibUAso0odbOaCDj3Q=="
       },
+      "Spectre.Console.Json": {
+        "type": "Transitive",
+        "resolved": "0.47.0",
+        "contentHash": "6nq5sCmYViulDjdMsTUpc5xD++aEsAHy9s9LKc1geif8slK9zJtze1PCjRHj2sRVN/alwBbL9/IyELDK4wTkeQ==",
+        "dependencies": {
+          "Spectre.Console": "0.47.0"
+        }
+      },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
         "resolved": "7.0.1",
@@ -346,6 +354,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.1, )",
+          "Spectre.Console.Json": "[0.47.0, )",
           "System.Data.Odbc": "[7.0.0, )",
           "System.IO.Abstractions": "[19.2.69, )",
           "YamlDotNet": "[13.5.2, )"


### PR DESCRIPTION
## What
Adds a ISerializer interface of which there are many implementations e.g JsonSerializer, YamlSerialzer etc

## Why
So the use can output whatever format they please