### PR TITLE
Cache

### DIFF
--- a/SierraSam.Core/IDatabase.cs
+++ b/SierraSam.Core/IDatabase.cs
@@ -24,8 +24,13 @@ public interface IDatabase
     /// </summary>
     /// <param name="schema">The database schema</param>
     /// <param name="table">The database table</param>
+    /// <param name="transaction">Optional database transaction</param>
     /// <returns>A collection of applied migrations</returns>
-    IReadOnlyCollection<AppliedMigration> GetSchemaHistory(string? schema = null, string? table = null);
+    IReadOnlyCollection<AppliedMigration> GetSchemaHistory(
+        string? schema = null,
+        string? table = null,
+        IDbTransaction? transaction = null
+    );
 
     int InsertSchemaHistory(AppliedMigration appliedMigration, IDbTransaction? transaction = null);
 

--- a/SierraSam.Core/MigrationApplicators/RepeatableMigrationApplicator.cs
+++ b/SierraSam.Core/MigrationApplicators/RepeatableMigrationApplicator.cs
@@ -35,7 +35,7 @@ public sealed class RepeatableMigrationApplicator : IMigrationApplicator
 
         try
         {
-            var appliedMigrations = _database.GetSchemaHistory();
+            var appliedMigrations = _database.GetSchemaHistory(transaction: transaction);
 
             if (appliedMigrations.Any(m => m.Checksum == pendingMigration.Checksum)) return 0;
 

--- a/SierraSam.Database/DatabaseResolver.cs
+++ b/SierraSam.Database/DatabaseResolver.cs
@@ -1,4 +1,6 @@
 ﻿using System.Data;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using SierraSam.Core;
 using SierraSam.Database.Databases;
 
@@ -8,17 +10,31 @@ public static class DatabaseResolver
 {
     // TODO: Make use of a proper connection string parser
     public static IDatabase Create(
+        ILoggerFactory loggerFactory,
         IDbConnection connection,
         IDbExecutor executor,
-        IConfiguration configuration)
+        IConfiguration configuration,
+        IMemoryCache cache)
     {
         var connectionString = configuration.Url;
 
         if (connectionString.Contains("postgres", StringComparison.InvariantCultureIgnoreCase))
         {
-            return new PostgresDatabase(connection, executor, configuration);
+            return new PostgresDatabase(
+                loggerFactory.CreateLogger<PostgresDatabase>(),
+                connection,
+                executor,
+                configuration,
+                cache
+            );
         }
 
-        return new MssqlDatabase(connection, executor, configuration);
+        return new MssqlDatabase(
+            loggerFactory.CreateLogger<MssqlDatabase>(),
+            connection,
+            executor,
+            configuration,
+            cache
+        );
     }
 }

--- a/SierraSam.Database/Databases/MssqlDatabase.cs
+++ b/SierraSam.Database/Databases/MssqlDatabase.cs
@@ -1,19 +1,27 @@
 ﻿using System.Data;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using SierraSam.Core;
 
 namespace SierraSam.Database.Databases;
 
 public sealed class MssqlDatabase : DefaultDatabase
 {
+    private readonly ILogger<MssqlDatabase> _logger;
     private readonly IConfiguration _configuration;
     private readonly IDbExecutor _dbExecutor;
 
     public MssqlDatabase(
+        ILogger<MssqlDatabase> logger,
         IDbConnection connection,
         IDbExecutor executor,
-        IConfiguration configuration)
-        : base(connection, executor, configuration)
+        IConfiguration configuration,
+        IMemoryCache cache)
+        : base(logger, connection, executor, configuration, cache)
     {
+        _logger = logger
+            ?? throw new ArgumentNullException(nameof(logger));
+
         _configuration = configuration
             ?? throw new ArgumentNullException(nameof(configuration));
 

--- a/SierraSam.Database/Databases/PostgresDatabase.cs
+++ b/SierraSam.Database/Databases/PostgresDatabase.cs
@@ -1,21 +1,29 @@
 ﻿using System.Data;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using SierraSam.Core;
 
 namespace SierraSam.Database.Databases;
 
 public sealed class PostgresDatabase : DefaultDatabase
 {
+    private readonly ILogger<PostgresDatabase> _logger;
     private readonly IConfiguration _configuration;
     private readonly IDbExecutor _dbExecutor;
 
     public PostgresDatabase(
+        ILogger<PostgresDatabase> logger,
         IDbConnection connection,
         IDbExecutor executor,
-        IConfiguration configuration)
-        : base(connection, executor, configuration)
+        IConfiguration configuration,
+        IMemoryCache cache)
+        : base(logger, connection, executor, configuration, cache)
     {
+        _logger = logger
+            ?? throw new ArgumentNullException(nameof(logger));
+
         _configuration = configuration
-                         ?? throw new ArgumentNullException(nameof(configuration));
+            ?? throw new ArgumentNullException(nameof(configuration));
 
         _dbExecutor = executor
             ?? throw new ArgumentNullException(nameof(executor));

--- a/SierraSam.Database/SierraSam.Database.csproj
+++ b/SierraSam.Database/SierraSam.Database.csproj
@@ -13,6 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     </ItemGroup>
 

--- a/SierraSam/SierraSam.csproj
+++ b/SierraSam/SierraSam.csproj
@@ -23,6 +23,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />

--- a/SierraSam/packages.lock.json
+++ b/SierraSam/packages.lock.json
@@ -2,6 +2,19 @@
   "version": 1,
   "dependencies": {
     "net7.0": {
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Direct",
+        "requested": "[7.0.0, )",
+        "resolved": "7.0.0",
+        "contentHash": "xpidBs2KCE2gw1JrD0quHE72kvCaI3xFql5/Peb2GRtUuZX+dYPoK/NTdVMiM67Svym0M0Df9A3xyU0FbMQhHw==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "7.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0",
+          "Microsoft.Extensions.Primitives": "7.0.0"
+        }
+      },
       "Microsoft.Extensions.Hosting": {
         "type": "Direct",
         "requested": "[7.0.1, )",
@@ -371,6 +384,7 @@
       "sierrasam.database": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "[7.0.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[7.0.1, )",
           "SierraSam.Core": "[1.0.0, )"
         }

--- a/SierraSam/packages.lock.json
+++ b/SierraSam/packages.lock.json
@@ -86,6 +86,14 @@
           "TestableIO.System.IO.Abstractions.Wrappers": "19.2.69"
         }
       },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "IeimUd0TNbhB4ded3AbgBLQv2SnsiVugDyGV1MvspQFVlA07nDC7Zul7kcwH5jWN3JiTcp/ySE83AIJo8yfKjg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "7.0.0"
+        }
+      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "7.0.0",


### PR DESCRIPTION
resolves #29 

## What
Inject memory cache into the database constructor. The cache is used for fetching the schema history table only at the moment.

## Why
So we don't query the database unnecessarily. 