### PR TITLE
Update to Oracle drivers

### DIFF
--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -2,6 +2,10 @@ name: Oracle
 
 on: workflow_call
 
+env:
+  MAJOR_VERSION: 21
+  MINOR_VERSION: 12
+
 jobs:
   test:
     runs-on: ubuntu-22.04
@@ -19,16 +23,16 @@ jobs:
       - name: Install Oracle ODBC Driver
         if: success()
         run: |
-          wget https://download.oracle.com/otn_software/linux/instantclient/2111000/instantclient-basiclite-linux.x64-21.11.0.0.0dbru.zip
-          wget https://download.oracle.com/otn_software/linux/instantclient/2111000/instantclient-odbc-linux.x64-21.11.0.0.0dbru.zip
-          unzip instantclient-basiclite-linux.x64-21.11.0.0.0dbru.zip -d /opt/oracle
-          unzip instantclient-odbc-linux.x64-21.11.0.0.0dbru.zip -d /opt/oracle
+          wget "https://download.oracle.com/otn_software/linux/instantclient/${{env.MAJOR_VERSION}}${{env.MINOR_VERSION}}000/instantclient-basiclite-linux.x64-${{env.MAJOR_VERSION}}.${{env.MINOR_VERSION}}.0.0.0dbru.zip"
+          wget "https://download.oracle.com/otn_software/linux/instantclient/${{env.MAJOR_VERSION}}${{env.MINOR_VERSION}}000/instantclient-odbc-linux.x64-${{env.MAJOR_VERSION}}.${{env.MINOR_VERSION}}.0.0.0dbru.zip"
+          unzip "instantclient-basiclite-linux.x64-${{env.MAJOR_VERSION}}.${{env.MINOR_VERSION}}.0.0.0dbru.zip" -d /opt/oracle
+          unzip "instantclient-odbc-linux.x64-${{env.MAJOR_VERSION}}.${{env.MINOR_VERSION}}.0.0.0dbru.zip" -d /opt/oracle
           sudo apt-get install -y glibc-source libaio1
-          sudo bash /opt/oracle/instantclient_21_11/odbc_update_ini.sh "/" "/opt/oracle/instantclient_21_11" "Oracle 21 ODBC driver" "OracleODBC-21" "/etc/odbc.ini"
+          sudo bash "/opt/oracle/instantclient_${{env.MAJOR_VERSION}}_${{env.MINOR_VERSION}}/odbc_update_ini.sh" "/" "/opt/oracle/instantclient_${{env.MAJOR_VERSION}}_${{env.MINOR_VERSION}}" "Oracle $MAJOR_VERSION ODBC driver" "OracleODBC-$MAJOR_VERSION" "/etc/odbc.ini"
       - name: Run Tests
         if: success()
         env:
-          LD_LIBRARY_PATH: /opt/oracle/instantclient_21_11
+          LD_LIBRARY_PATH: "/opt/oracle/instantclient_${{env.MAJOR_VERSION}}_${{env.MINOR_VERSION}}"
         run: |
           dotnet test \
           --no-restore \

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -27,7 +27,7 @@ jobs:
           wget "https://download.oracle.com/otn_software/linux/instantclient/${{env.MAJOR_VERSION}}${{env.MINOR_VERSION}}000/instantclient-odbc-linux.x64-${{env.MAJOR_VERSION}}.${{env.MINOR_VERSION}}.0.0.0dbru.zip"
           unzip "instantclient-basiclite-linux.x64-${{env.MAJOR_VERSION}}.${{env.MINOR_VERSION}}.0.0.0dbru.zip" -d /opt/oracle
           unzip "instantclient-odbc-linux.x64-${{env.MAJOR_VERSION}}.${{env.MINOR_VERSION}}.0.0.0dbru.zip" -d /opt/oracle
-          sudo apt-get install -y glibc-source libaio1
+          sudo apt-get update && sudo apt-get install -y glibc-source libaio1
           sudo bash "/opt/oracle/instantclient_${{env.MAJOR_VERSION}}_${{env.MINOR_VERSION}}/odbc_update_ini.sh" "/" "/opt/oracle/instantclient_${{env.MAJOR_VERSION}}_${{env.MINOR_VERSION}}" "Oracle $MAJOR_VERSION ODBC driver" "OracleODBC-$MAJOR_VERSION" "/etc/odbc.ini"
       - name: Run Tests
         if: success()


### PR DESCRIPTION
Update Oracle instant client and ODBC driver from `21.11` to `21.12`. Additionally parameterized the major and minor version for easy upgrade in the future. 